### PR TITLE
Bump nodejs to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     description: "Silence all stderr output"
     default: "false"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/main/index.js"
   post: "dist/post/index.js"
   post-if: success()


### PR DESCRIPTION
node12 is deprecated and will stop working in summer 2023

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Itxaka <igarcia@suse.com>